### PR TITLE
Add hacky support for columns

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -73,6 +73,11 @@
       width: 90%;
       max-width: 40em;
     }
+    
+    .chat-columns {
+      max-width: 90%;
+      column-width: 30em;
+    }
 
     header {
       background-color: #ad4949;
@@ -416,7 +421,7 @@
     </div>
 
     <main>
-      <section class="column">
+      <section class="column chat-columns">
 
         <!-- <div>
           <div id="image">


### PR DESCRIPTION
Things get split into n columns for screens (1.11 * 30em * [n, n+1]) wide.
Not sure if I should merge the two column classes. It should look pretty misaligned currently.