### PR TITLE
Make colors a bit more random

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -807,9 +807,10 @@
     }
 
     function colorForHash(hash) {
-      const hue = hash % 360
-      const sat = Math.abs(hash) % 30 + 5
-      const light = Math.abs(hash) % 20 + 40
+      const uhash = hash < 0 ? hash + 4294967296 : hash
+      const hue = (uhash >>> 8) % 360
+      const sat = (uhash >>> 4) % 30 + 5
+      const light = uhash % 20 + 40
       return `hsl(${hue}, ${sat}%, ${light}%)`
     }
 


### PR DESCRIPTION
Current color generation often ends up with a common final digit, since
`gcd(20, 40, 360)` is 10. By shifting the hash around and using some other
portions, we should be able to remove this correlation.

The `uhash` step converts an int32 hash to uint32.